### PR TITLE
 ci: add Makefile, workflow, pre-commit hooks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,35 @@
+name: test
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install libcups3
+        run: |
+          sudo apt update
+          sudo apt install --yes autoconf build-essential libavahi-client-dev libnss-mdns libpng-dev libssl-dev zlib1g-dev
+          git clone --recurse-submodules https://github.com/OpenPrinting/libcups
+          pushd libcups
+          git checkout --recurse-submodules af31f816fe406ad944d7e429ca088605eeb7dc47
+          ./configure
+          make
+          sudo make install
+          popd
+          rm -rf libcups
+
+      - name: Setup environment
+        run: |
+          sudo apt install --yes python3-dev
+          make setup
+
+      - name: Run linters
+        run: |
+          make lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: "v6.0.0"
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.12.9"
+    hooks:
+      # Run the linter
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      # Run the formatter
+      - id: ruff-format

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,189 @@
+PROJECT=cups
+UV_LINT_GROUPS := "--group=lint"
+SOURCES=$(wildcard *.py) $(PROJECT)
+
+ifneq ($(OS),Windows_NT)
+	OS := $(shell uname)
+endif
+ifdef CI
+	APT := apt-get --yes
+else
+	APT := apt-get
+endif
+
+.DEFAULT_GOAL := help
+
+.ONESHELL:
+
+.SHELLFLAGS = -ec
+
+.PHONY: help
+help: ## Show this help.
+	@printf "\e[1m%-30s\e[0m | \e[1m%s\e[0m\n" "Target" "Description"
+	printf "\e[2m%-30s + %-41s\e[0m\n" "------------------------------" "------------------------------------------------"
+	egrep --with-filename '^[^:]+\: [^#]*##' $$(echo $(MAKEFILE_LIST) | tac --separator=' ') | sed -e 's/^[^:]*://' -e 's/:[^#]*/ /' | sort -V| awk -F '[: ]*' \
+	'{
+		if ($$2 == "##")
+		{
+			$$1=sprintf(" %-28s", $$1);
+			$$2=" | ";
+			print $$0;
+		}
+		else
+		{
+			$$1=sprintf("  └ %-25s", $$1);
+			$$2=" | ";
+			$$3=sprintf(" └ %s", $$3);
+			print $$0;
+		}
+	}' | uniq
+
+.PHONY: setup
+setup: install-uv  _setup-lint setup-precommit  ## Set up a development environment
+	uv sync --group=lint
+
+.PHONY: setup-lint
+setup-lint: _setup-lint  ##- Set up a linting-only environment
+	uv sync --group=lint
+
+.PHONY: _setup-lint
+_setup-lint: install-uv install-pyright
+
+.PHONY: setup-precommit
+setup-precommit: install-uv  ##- Set up pre-commit hooks in this repository.
+ifeq ($(shell which pre-commit),)
+	uv tool run pre-commit install
+else
+	pre-commit install
+endif
+
+.PHONY: clean
+clean:  ## Clean up the development environment
+	uv tool run pyclean .
+	rm -rf build/
+
+.PHONY: format-ruff
+format-ruff: install-ruff  ##- Automatically format with ruff
+	success=true
+	ruff check --fix $(SOURCES) || success=false
+	ruff format $(SOURCES)
+	$$success || exit 1
+
+.PHONY: format-codespell
+format-codespell:  ##- Fix spelling issues with codespell
+	uv run codespell --toml pyproject.toml --write-changes $(SOURCES)
+
+.PHONY: format-pre-commit
+format-pre-commit:  ##- Format the entire repository using pre-commit
+	uv tool run pre-commit run
+
+.PHONY: lint-ruff
+lint-ruff: install-ruff  ##- Lint with ruff
+ifneq ($(CI),)
+	@echo ::group::$@
+endif
+	ruff check $(SOURCES)
+	ruff format --diff $(SOURCES)
+ifneq ($(CI),)
+	@echo ::endgroup::
+endif
+
+.PHONY: lint-codespell
+lint-codespell: install-codespell  ##- Check spelling with codespell
+ifneq ($(CI),)
+	@echo ::group::$@
+endif
+	uv run codespell --toml pyproject.toml $(SOURCES)
+ifneq ($(CI),)
+	@echo ::endgroup::
+endif
+
+.PHONY: lint-mypy
+lint-mypy:  ##- Check types with mypy
+ifneq ($(CI),)
+	@echo ::group::$@
+endif
+	uv run mypy --show-traceback --show-error-codes $(PROJECT)
+ifneq ($(CI),)
+	@echo ::endgroup::
+endif
+
+.PHONY: lint-pyright
+lint-pyright:  ##- Check types with pyright
+ifneq ($(CI),)
+	@echo ::group::$@
+endif
+ifneq ($(shell which pyright),) # Prefer the system pyright
+	pyright --pythonpath .venv/bin/python
+else
+	uv tool run pyright --pythonpath .venv/bin/python
+endif
+ifneq ($(CI),)
+	@echo ::endgroup::
+endif
+
+# Below are intermediate targets for setup. They are not included in help as they should
+# not be used independently.
+
+.PHONY: install-uv
+install-uv:
+ifneq ($(shell which uv),)
+else ifneq ($(shell which snap),)
+	sudo snap install --classic astral-uv
+else ifneq ($(shell which brew),)
+	brew install uv
+else ifeq ($(OS),Windows_NT)
+	pwsh -c "irm https://astral.sh/uv/install.ps1 | iex"
+else
+	curl -LsSf https://astral.sh/uv/install.sh | sh
+endif
+
+.PHONY: install-codespell
+install-codespell:
+ifneq ($(shell which codespell),)
+else ifneq ($(shell which snap),)
+	sudo snap install codespell
+else ifneq ($(shell which brew),)
+	make install-uv
+	uv tool install codespell
+else
+	$(warning Codespell not installed. Please install it yourself.)
+endif
+
+.PHONY: install-pyright
+install-pyright: install-uv
+ifneq ($(shell which pyright),)
+else ifneq ($(shell which snap),)
+	sudo snap install --classic pyright
+else
+	# Workaround for a bug in npm
+	[ -d "$(HOME)/.npm/_cacache" ] && chown -R `id -u`:`id -g` "$(HOME)/.npm" || true
+	uv tool install pyright
+endif
+
+.PHONY: install-ruff
+install-ruff:
+ifneq ($(shell which ruff),)
+else ifneq ($(shell which snap),)
+	sudo snap install ruff
+else
+	make install-uv
+	uv tool install ruff
+endif
+
+.PHONY: install-npm
+install-npm:
+ifneq ($(shell which npm),)
+else ifneq ($(shell which snap),)
+	sudo snap install --classic node
+else ifneq ($(shell which brew),)
+	brew install node
+else
+	$(error npm not installed. Please install it yourself.)
+endif
+
+.PHONY: format
+format: format-ruff format-codespell format-pre-commit  ## Run all automatic formatters
+
+.PHONY: lint
+lint: lint-ruff lint-codespell lint-mypy lint-pyright  ## Run all linters

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ Then, install this from source using the command
 
 `pip install -e .`
 
+### Developing
+
+Set up a virtual environment and install dependencies with:
+
+```bash
+make setup
+```
+
+See all Make targets with:
+
+```bash
+make help
+```
+
 ### Testing
 
 To test this, run the [`test/test.py`](test/test.py) file. We cannot test `addDests` and `setDests` without doing destructive changes in the system, so they're not yet added in the test. This is a proof-of-concept test. So, please run it with caution.

--- a/cups/__init__.py
+++ b/cups/__init__.py
@@ -1,4 +1,4 @@
-from ._cups import ffi, lib  # noqa: D104
+from ._cups import ffi, lib  # type: ignore[import-not-found]  # noqa: D104
 from .connection import (
     Connection,
 )
@@ -21,8 +21,8 @@ from .generic import (
     setUserAgent,
 )
 
-del connection  # noqa: F821
-del generic  # noqa: F821
+del connection  # type: ignore[name-defined]  # noqa: F821
+del generic  # type: ignore[name-defined]  # noqa: F821
 
 __all__ = [
     "Connection",

--- a/cups/__init__.py
+++ b/cups/__init__.py
@@ -1,3 +1,4 @@
+from ._cups import ffi, lib  # noqa: D104
 from .connection import (
     Connection,
 )
@@ -7,23 +8,21 @@ from .generic import (
     copyDest,
     getDestWithURI,
     getEncryption,
-    setEncryption,
     getError,
     getPort,
-    setPort,
     getServer,
-    setServer,
     getUser,
-    setUser,
     getUserAgent,
-    setUserAgent,
     setDefaultDest,
+    setEncryption,
+    setPort,
+    setServer,
+    setUser,
+    setUserAgent,
 )
 
-from ._cups import lib, ffi
-
-del connection  # noqa
-del generic  # noqa
+del connection  # noqa: F821
+del generic  # noqa: F821
 
 __all__ = [
     "Connection",

--- a/cups/build_cups.py
+++ b/cups/build_cups.py
@@ -1,6 +1,6 @@
 import os  # noqa: D100
 
-import pkgconfig
+import pkgconfig  # type: ignore[import-untyped]
 from cffi import FFI
 
 LIBRARY = "cups3"

--- a/cups/build_cups.py
+++ b/cups/build_cups.py
@@ -1,14 +1,15 @@
-from cffi import FFI
-import os
+import os  # noqa: D100
+
 import pkgconfig
+from cffi import FFI
 
 LIBRARY = "cups3"
 VERSION = "3.0rc4"
 
 
-def get_include_dirs():
+def get_include_dirs():  # noqa: ANN201, D103
     if not (pkgconfig.installed(LIBRARY, f"<={VERSION}")):
-        raise Exception(
+        raise Exception(  # noqa: TRY002, TRY003
             "Cannot find pkg-config file for cups3.\nIs CUPS 3.0 development libraries properly installed?"
         )
     cflags = [c[2:] for c in (pkgconfig.cflags(LIBRARY).split(" "))]
@@ -25,7 +26,7 @@ INCLUDE_DIRS, LIBRARY_DIRS = get_include_dirs()
 ffibuilder = FFI()
 
 cdefs = ""
-dir_path = os.path.join(os.path.dirname(__file__), "headers/")
+dir_path = os.path.join(os.path.dirname(__file__), "headers/")  # noqa: PTH118, PTH120
 headers = [
     "base.h",
     "array.h",
@@ -46,8 +47,8 @@ headers = [
 ]
 print(dir_path)
 for file in headers:
-    file_path = os.path.join(dir_path, file)
-    with open(file_path) as f:
+    file_path = os.path.join(dir_path, file)  # noqa: PTH118
+    with open(file_path) as f:  # noqa: PTH123
         cdefs += f.read()
 
 ffibuilder.cdef(cdefs)

--- a/cups/connection/__init__.py
+++ b/cups/connection/__init__.py
@@ -1,4 +1,8 @@
+import socket  # noqa: D104
+from typing import Any, Optional
+
 from cups import _cups
+from cups.enums.http import HttpEncryption, HttpStatus
 from cups.generic import (
     getEncryption,
     getPort,
@@ -9,15 +13,11 @@ from cups.generic import (
     setServer,
     setUser,
 )
-from cups.enums.http import HttpEncryption, HttpStatus
-from typing import Any, Optional
-
-from .dests import DestsMixin
-from .jobs import JobMixin
-from .base import _Base
 from cups.utils import _bytes_to_value
 
-import socket
+from .base import _Base
+from .dests import DestsMixin
+from .jobs import JobMixin
 
 _ffi = _cups.ffi
 _lib = _cups.lib
@@ -35,7 +35,7 @@ class Connection(DestsMixin, JobMixin, _Base):
         return getServer()
 
     @host.setter
-    def host(self, host: str):
+    def host(self, host: str) -> None:
         setServer(host)
 
     @property
@@ -44,7 +44,7 @@ class Connection(DestsMixin, JobMixin, _Base):
         return getPort()
 
     @port.setter
-    def port(self, port: int):
+    def port(self, port: int) -> None:
         setPort(port)
 
     @property
@@ -53,15 +53,15 @@ class Connection(DestsMixin, JobMixin, _Base):
         return getEncryption()
 
     @encryption.setter
-    def encryption(self, encryption: HttpEncryption):
+    def encryption(self, encryption: HttpEncryption) -> None:
         setEncryption(encryption)
 
     @property
-    def user(self) -> str:
+    def user(self) -> str:  # noqa: D102
         return getUser()
 
     @user.setter
-    def user(self, user: str):
+    def user(self, user: str) -> None:
         setUser(user)
 
     def __init__(
@@ -71,7 +71,7 @@ class Connection(DestsMixin, JobMixin, _Base):
         encryption: Optional[HttpEncryption] = None,
         family: socket.AddressFamily = socket.AF_UNSPEC,
         msec: int = 0,
-    ):
+    ) -> None:
         if host:
             self.host = host
 
@@ -85,23 +85,32 @@ class Connection(DestsMixin, JobMixin, _Base):
         c_port = _ffi.cast("int", self.port)
         c_encryption = _ffi.cast("http_encryption_t", self.encryption)
         self.http = _lib.httpConnect(
-            c_host, c_port, _ffi.NULL, family, c_encryption, True, msec, _ffi.NULL
+            c_host,
+            c_port,
+            _ffi.NULL,
+            family,
+            c_encryption,
+            True,  # noqa: FBT003
+            msec,
+            _ffi.NULL,
         )
 
-    def connectAgain(self, msec: int) -> bool:
+    def connectAgain(self, msec: int) -> bool:  # noqa: D102, N802
         return bool(_lib.httpConnectAgain(self.http, msec, _ffi.NULL))
 
-    def doAuthentication(self, method: str, resource: str) -> bool:
-        return bool(_lib.cupsDoAuthentication(self.http, method.encode(), resource.encode()))
+    def doAuthentication(self, method: str, resource: str) -> bool:  # noqa: D102, N802
+        return bool(
+            _lib.cupsDoAuthentication(self.http, method.encode(), resource.encode())
+        )
 
-    def getPassword(self, prompt: str, method: str, resource: str) -> str:
+    def getPassword(self, prompt: str, method: str, resource: str) -> str:  # noqa: D102, N802
         return _bytes_to_value(
             _lib.cupsGetPassword(
                 prompt.encode(), self.http, method.encode(), resource.encode()
             )
         )
 
-    def getFile(self, resource: str, filname: str) -> HttpStatus:
+    def getFile(self, resource: str, filename: str) -> HttpStatus:  # noqa: D102, N802
         return HttpStatus(
-            _lib.cupsGetFile(self.http, resource.encode(), filname.encode())
+            _lib.cupsGetFile(self.http, resource.encode(), filename.encode())
         )

--- a/cups/connection/__init__.py
+++ b/cups/connection/__init__.py
@@ -32,7 +32,7 @@ class Connection(DestsMixin, JobMixin, _Base):
     @property
     def host(self) -> str:
         """Return the host of the CUPS server."""
-        return getServer()
+        return getServer()  # type: ignore[return-value]
 
     @host.setter
     def host(self, host: str) -> None:
@@ -58,7 +58,7 @@ class Connection(DestsMixin, JobMixin, _Base):
 
     @property
     def user(self) -> str:  # noqa: D102
-        return getUser()
+        return getUser()  # type: ignore[return-value]
 
     @user.setter
     def user(self, user: str) -> None:
@@ -104,7 +104,7 @@ class Connection(DestsMixin, JobMixin, _Base):
         )
 
     def getPassword(self, prompt: str, method: str, resource: str) -> str:  # noqa: D102, N802
-        return _bytes_to_value(
+        return _bytes_to_value(  # type: ignore[return-value]
             _lib.cupsGetPassword(
                 prompt.encode(), self.http, method.encode(), resource.encode()
             )

--- a/cups/connection/base.py
+++ b/cups/connection/base.py
@@ -1,7 +1,7 @@
-from typing import Any
-from cups import _cups
-from cups.types.ipp import IPPRequest, IPPStatus, IPPError
+from typing import Any  # noqa: D100
+
 from cups.enums.ipp import IPPOp, IPPTag
+from cups.types.ipp import IPPRequest
 
 
 class _Base:

--- a/cups/connection/base.py
+++ b/cups/connection/base.py
@@ -7,7 +7,7 @@ from cups.types.ipp import IPPRequest
 class _Base:
     http: Any
 
-    def _add_or_modify_printer(self, name: str) -> None:
+    def _add_or_modify_printer(self, name: str) -> IPPRequest:
         uri: str = f"ipp://localhost/printers/{name}"
         req: IPPRequest = IPPRequest(IPPOp.CUPS_ADD_MODIFY_PRINTER)
         req.addString(

--- a/cups/connection/dests.py
+++ b/cups/connection/dests.py
@@ -25,7 +25,7 @@ class DestsMixin(_Base):  # noqa: D101
         return cupsDest.from_cffi_list(dests=c_dests, count=count)
 
     def getDefault(self) -> str:  # noqa: D102, N802
-        return _bytes_to_value(_lib.cupsGetDefault(self.http))
+        return _bytes_to_value(_lib.cupsGetDefault(self.http))  # type: ignore[return-value]
 
     def getDests(self) -> dict[str, cupsDest]:  # noqa: D102, N802
         dests: cupsDest = cupsDest("**")
@@ -34,8 +34,8 @@ class DestsMixin(_Base):  # noqa: D101
         return cupsDest.from_cffi_list(dests=dests, count=count)
 
     def setDests(self, dests: list[cupsDest]) -> bool:  # noqa: D102, N802
-        return _bytes_to_value(
-            _lib.cupsSetDests(self.http, len(dests), cupsDest.to_cffi_list(dests))
+        return _bytes_to_value(  # type: ignore[return-value]
+            _lib.cupsSetDests(self.http, len(dests), cupsDest.to_cffi_list(dests))  # type: ignore[arg-type]
         )
 
     def copyDestInfo(  # noqa: D102, N802

--- a/cups/connection/dests.py
+++ b/cups/connection/dests.py
@@ -1,11 +1,8 @@
+from typing import Any, Optional  # noqa: D100
+
 from cups import _cups
-from cups.types.cups import cupsDest, cupsDestInfo
-from cups.types.media import cupsMedia
-from cups.types.ipp import IPPAttribute, IPPRequest, IPPStatus, IPPError
 from cups.enums.cups import CUPSDestFlags
-from cups.enums.media import CUPSMediaFlags
-from cups.enums.ipp import IPPOp, IPPTag
-from typing import Any, Dict, Optional
+from cups.types.cups import cupsDest, cupsDestInfo
 from cups.utils import _bytes_to_value
 
 from .base import _Base
@@ -14,10 +11,10 @@ _ffi = _cups.ffi
 _lib = _cups.lib
 
 
-class DestsMixin(_Base):
+class DestsMixin(_Base):  # noqa: D101
     http: Any
 
-    def addDest(self, name: str, instance: Optional[str] = None) -> Dict[str, cupsDest]:
+    def addDest(self, name: str, instance: Optional[str] = None) -> dict[str, cupsDest]:  # noqa: D102, N802
         dests = self.getDests()
         c_name = _ffi.new("char[]", name.encode("utf-8"))
         c_instance = (
@@ -27,28 +24,28 @@ class DestsMixin(_Base):
         count = _lib.cupsAddDest(c_name, c_instance, len(dests), c_dests)
         return cupsDest.from_cffi_list(dests=c_dests, count=count)
 
-    def getDefault(self) -> str:
+    def getDefault(self) -> str:  # noqa: D102, N802
         return _bytes_to_value(_lib.cupsGetDefault(self.http))
 
-    def getDests(self) -> Dict[str, cupsDest]:
+    def getDests(self) -> dict[str, cupsDest]:  # noqa: D102, N802
         dests: cupsDest = cupsDest("**")
         count: int = _lib.cupsGetDests(self.http, dests.ffi_value)
 
         return cupsDest.from_cffi_list(dests=dests, count=count)
 
-    def setDests(self, dests: list[cupsDest]) -> bool:
+    def setDests(self, dests: list[cupsDest]) -> bool:  # noqa: D102, N802
         return _bytes_to_value(
             _lib.cupsSetDests(self.http, len(dests), cupsDest.to_cffi_list(dests))
         )
 
-    def copyDestInfo(
+    def copyDestInfo(  # noqa: D102, N802
         self, dest: cupsDest, flags: CUPSDestFlags = CUPSDestFlags.NONE
     ) -> cupsDestInfo:
         return cupsDestInfo(
             _lib.cupsCopyDestInfo(self.http, dest.ffi_value, flags.value)
         )
 
-    def checkDestSupported(
+    def checkDestSupported(  # noqa: D102, N802
         self,
         dest: cupsDest,
         dinfo: cupsDestInfo,

--- a/cups/connection/document.py
+++ b/cups/connection/document.py
@@ -4,7 +4,7 @@ from cups.enums.http import HttpStatus
 from cups.enums.ipp import IPPStatus
 from cups.types.cups import cupsDest, cupsDestInfo, cupsOption
 
-from .base import _Base, _cups
+from .base import _Base, _cups  # type: ignore[attr-defined]
 
 _lib = _cups.lib
 

--- a/cups/connection/document.py
+++ b/cups/connection/document.py
@@ -1,24 +1,26 @@
-from cups.types.cups import cupsDest, cupsDestInfo, cupsOption
+from typing import Any  # noqa: D100
+
 from cups.enums.http import HttpStatus
 from cups.enums.ipp import IPPStatus
+from cups.types.cups import cupsDest, cupsDestInfo, cupsOption
+
 from .base import _Base, _cups
-from typing import Any, Dict
 
 _lib = _cups.lib
 
 
-class DocumentMixin(_Base):
+class DocumentMixin(_Base):  # noqa: D101
     http: Any
 
-    def startDestDocument(
+    def startDestDocument(  # noqa: D102, N802, PLR0913
         self,
         dest: cupsDest,
         dest_info: cupsDestInfo,
         job_id: int,
         docname: str,
-        format: str,
-        options: Dict[str, cupsOption],
-        last_document: bool,
+        format: str,  # noqa: A002
+        options: dict[str, cupsOption],
+        last_document: bool,  # noqa: FBT001
     ) -> HttpStatus:
         status = _lib.cupsStartDestDocument(
             self.http,
@@ -33,10 +35,10 @@ class DocumentMixin(_Base):
         )
         return HttpStatus(status)
 
-    def finishDestDocument(self, dest: cupsDest, dinfo: cupsDestInfo) -> IPPStatus:
+    def finishDestDocument(self, dest: cupsDest, dinfo: cupsDestInfo) -> IPPStatus:  # noqa: D102, N802
         return IPPStatus(
             _lib.cupsFinishDestDocument(self.http, dest.ffi_value, dinfo.ffi_value)
         )
 
-    def writeRequestData(self, buffer: str, len: int) -> HttpStatus:
+    def writeRequestData(self, buffer: str, len: int) -> HttpStatus:  # noqa: A002, D102, N802
         return HttpStatus(_lib.cupsWriteRequestData(self.http, buffer.encode(), len))

--- a/cups/connection/jobs.py
+++ b/cups/connection/jobs.py
@@ -14,7 +14,7 @@ class JobMixin:  # noqa: D101
         self, name: str, op: IPPOp, reason: Optional[str] = None
     ) -> None:
         uri: str = f"ipp://localhost/printers/{name}"
-        req: IPPRequest = IPPRequest.cffi_new(op)
+        req: IPPRequest = IPPRequest.cffi_new(op)  # type: ignore[attr-defined]
         req.addString(
             group=IPPTag.OPERATION, value_tag=IPPTag.URI, name="printer-uri", value=uri
         )

--- a/cups/connection/jobs.py
+++ b/cups/connection/jobs.py
@@ -1,15 +1,18 @@
+from typing import Any, Optional  # noqa: D100
+
 from cups import _cups
 from cups.enums.ipp import IPPOp, IPPStatus, IPPTag
 from cups.types.ipp import IPPError, IPPRequest
-from typing import Any, Optional
 
 _lib = _cups.lib
 
 
-class JobMixin:
+class JobMixin:  # noqa: D101
     http: Any
 
-    def _do_printer_request(self, name: str, op: IPPOp, reason: Optional[str] = None) -> None:
+    def _do_printer_request(
+        self, name: str, op: IPPOp, reason: Optional[str] = None
+    ) -> None:
         uri: str = f"ipp://localhost/printers/{name}"
         req: IPPRequest = IPPRequest.cffi_new(op)
         req.addString(
@@ -31,10 +34,8 @@ class JobMixin:
         if not answer or answer.statuscode > IPPStatus.OK_CONFLICTING:
             raise IPPError(answer)
 
-        return None
-
-    def acceptJobs(self, queue_name: str) -> None:
+    def acceptJobs(self, queue_name: str) -> None:  # noqa: D102, N802
         return self._do_printer_request(queue_name, op=IPPOp.CUPS_ACCEPT_JOBS)
 
-    def rejectJobs(self, queue_name: str) -> None:
+    def rejectJobs(self, queue_name: str) -> None:  # noqa: D102, N802
         return self._do_printer_request(queue_name, op=IPPOp.CUPS_REJECT_JOBS)

--- a/cups/enums/__init__.py
+++ b/cups/enums/__init__.py
@@ -1,7 +1,7 @@
-from .cups import CUPSDestFlags
+from .cups import CUPSDestFlags  # noqa: D104
+from .encoding import CUPSEncoding
 from .http import HttpEncryption
 from .ipp import IPPOp, IPPRes, IPPState, IPPStatus, IPPTag
-from .encoding import CUPSEncoding
 
 __all__ = [
     "CUPSDestFlags",

--- a/cups/enums/cups.py
+++ b/cups/enums/cups.py
@@ -1,10 +1,11 @@
-from enum import IntFlag
+from enum import IntFlag  # noqa: D100
+
 from cups import _cups
 
 _lib = _cups.lib
 
 
-class CUPSDestFlags(IntFlag):
+class CUPSDestFlags(IntFlag):  # noqa: D101
     NONE = _lib.CUPS_DEST_FLAGS_NONE
     UNCONNECTED = _lib.CUPS_DEST_FLAGS_UNCONNECTED
     MORE = _lib.CUPS_DEST_FLAGS_MORE

--- a/cups/enums/encoding.py
+++ b/cups/enums/encoding.py
@@ -1,10 +1,12 @@
-from enum import IntFlag
+from enum import IntFlag  # noqa: D100
+
 from cups import _cups
 from cups.utils import _bytes_to_value
 
 _lib = _cups.lib
 
-class CUPSEncoding(IntFlag):
+
+class CUPSEncoding(IntFlag):  # noqa: D101
     BG18030 = _lib.CUPS_ENCODING_BG18030
     EUC_CN = _lib.CUPS_ENCODING_EUC_CN
     EUC_JP = _lib.CUPS_ENCODING_EUC_JP
@@ -47,11 +49,11 @@ class CUPSEncoding(IntFlag):
     WINDOWS_949 = _lib.CUPS_ENCODING_WINDOWS_949
     WINDOWS_950 = _lib.CUPS_ENCODING_WINDOWS_950
 
-    def __str__(self):
+    def __str__(self) -> str:
         return _bytes_to_value(_lib.cupsEncodingString(self.value))
 
     @classmethod
-    def _missing_(cls, value):
+    def _missing_(cls, value):  # noqa: ANN001, ANN206
         if isinstance(value, str):
             enc = _lib.cupsEncodingValue(value.encode())
             return cls(enc)

--- a/cups/enums/encoding.py
+++ b/cups/enums/encoding.py
@@ -50,7 +50,7 @@ class CUPSEncoding(IntFlag):  # noqa: D101
     WINDOWS_950 = _lib.CUPS_ENCODING_WINDOWS_950
 
     def __str__(self) -> str:
-        return _bytes_to_value(_lib.cupsEncodingString(self.value))
+        return _bytes_to_value(_lib.cupsEncodingString(self.value))  # type: ignore[return-value]
 
     @classmethod
     def _missing_(cls, value):  # noqa: ANN001, ANN206

--- a/cups/enums/http.py
+++ b/cups/enums/http.py
@@ -1,17 +1,18 @@
-from enum import IntFlag
+from enum import IntFlag  # noqa: D100
+
 from cups import _cups
 
 _lib = _cups.lib
 
 
-class HttpEncryption(IntFlag):
+class HttpEncryption(IntFlag):  # noqa: D101
     IF_REQUESTED = _lib.HTTP_ENCRYPTION_IF_REQUESTED
     NEVER = _lib.HTTP_ENCRYPTION_NEVER
     REQUIRED = _lib.HTTP_ENCRYPTION_REQUIRED
     ALWAYS = _lib.HTTP_ENCRYPTION_ALWAYS
 
 
-class HttpStatus(IntFlag):
+class HttpStatus(IntFlag):  # noqa: D101
     ACCEPTED = _lib.HTTP_STATUS_ACCEPTED
     ALREADY_REPORTED = _lib.HTTP_STATUS_ALREADY_REPORTED
     BAD_GATEWAY = _lib.HTTP_STATUS_BAD_GATEWAY

--- a/cups/enums/ipp.py
+++ b/cups/enums/ipp.py
@@ -1,11 +1,12 @@
-from enum import IntFlag
+from enum import IntFlag  # noqa: D100
+
 from cups import _cups
 from cups.utils import _bytes_to_value
 
 _lib = _cups.lib
 
 
-class IPPOp(IntFlag):
+class IPPOp(IntFlag):  # noqa: D101
     ACKNOWLEDGE_DOCUMENT = _lib.IPP_OP_ACKNOWLEDGE_DOCUMENT
     ACKNOWLEDGE_ENCRYPTED_JOB_ATTRIBUTES = (
         _lib.IPP_OP_ACKNOWLEDGE_ENCRYPTED_JOB_ATTRIBUTES
@@ -132,18 +133,18 @@ class IPPOp(IntFlag):
     VALIDATE_DOCUMENT = _lib.IPP_OP_VALIDATE_DOCUMENT
     VALIDATE_JOB = _lib.IPP_OP_VALIDATE_JOB
 
-    def __str__(self):
+    def __str__(self) -> str:
         return _bytes_to_value(_lib.ippOpString(self.value))
 
     @classmethod
-    def _missing_(cls, value):
+    def _missing_(cls, value):  # noqa: ANN001, ANN206
         if isinstance(value, str):
             op = _lib.ippOpValue(value.encode())
             return cls(op)
         return None
 
 
-class IPPTag(IntFlag):
+class IPPTag(IntFlag):  # noqa: D101
     ADMINDEFINE = _lib.IPP_TAG_ADMINDEFINE
     BEGIN_COLLECTION = _lib.IPP_TAG_BEGIN_COLLECTION
     BOOLEAN = _lib.IPP_TAG_BOOLEAN
@@ -188,7 +189,7 @@ class IPPTag(IntFlag):
     ZERO = _lib.IPP_TAG_ZERO
 
 
-class IPPState(IntFlag):
+class IPPState(IntFlag):  # noqa: D101
     ATTRIBUTE = _lib.IPP_STATE_ATTRIBUTE
     DATA = _lib.IPP_STATE_DATA
     ERROR = _lib.IPP_STATE_ERROR
@@ -196,7 +197,7 @@ class IPPState(IntFlag):
     IDLE = _lib.IPP_STATE_IDLE
 
 
-class IPPStatus(IntFlag):
+class IPPStatus(IntFlag):  # noqa: D101
     CUPS_INVALID = _lib.IPP_STATUS_CUPS_INVALID
     ERROR_ACCOUNT_AUTHORIZATION_FAILED = (
         _lib.IPP_STATUS_ERROR_ACCOUNT_AUTHORIZATION_FAILED
@@ -262,6 +263,6 @@ class IPPStatus(IntFlag):
     OK_TOO_MANY_EVENTS = _lib.IPP_STATUS_OK_TOO_MANY_EVENTS
 
 
-class IPPRes(IntFlag):
+class IPPRes(IntFlag):  # noqa: D101
     CM = _lib.IPP_RES_PER_CM
     INCH = _lib.IPP_RES_PER_INCH

--- a/cups/enums/ipp.py
+++ b/cups/enums/ipp.py
@@ -134,7 +134,7 @@ class IPPOp(IntFlag):  # noqa: D101
     VALIDATE_JOB = _lib.IPP_OP_VALIDATE_JOB
 
     def __str__(self) -> str:
-        return _bytes_to_value(_lib.ippOpString(self.value))
+        return _bytes_to_value(_lib.ippOpString(self.value))  # type: ignore[return-value]
 
     @classmethod
     def _missing_(cls, value):  # noqa: ANN001, ANN206

--- a/cups/enums/jobs.py
+++ b/cups/enums/jobs.py
@@ -1,10 +1,11 @@
-from enum import IntFlag
+from enum import IntFlag  # noqa: D100
+
 from cups import _cups
 
 _lib = _cups.lib
 
 
-class WhichJobs(IntFlag):
+class WhichJobs(IntFlag):  # noqa: D101
     ACTIVE = _lib.CUPS_WHICHJOBS_ACTIVE
     ALL = _lib.CUPS_WHICHJOBS_ALL
     COMPLETED = _lib.CUPS_WHICHJOBS_COMPLETED

--- a/cups/enums/media.py
+++ b/cups/enums/media.py
@@ -1,10 +1,11 @@
-from enum import IntFlag
+from enum import IntFlag  # noqa: D100
+
 from cups import _cups
 
 _lib = _cups.lib
 
 
-class CUPSMediaFlags(IntFlag):
+class CUPSMediaFlags(IntFlag):  # noqa: D101
     BORDERLESS = _lib.CUPS_MEDIA_FLAGS_BORDERLESS
     DEFAULT = _lib.CUPS_MEDIA_FLAGS_DEFAULT
     DUPLEX = _lib.CUPS_MEDIA_FLAGS_DUPLEX

--- a/cups/generic.py
+++ b/cups/generic.py
@@ -1,5 +1,5 @@
 from pathlib import Path  # noqa: D100
-from typing import Optional
+from typing import Optional, Union
 
 from cups import _cups
 from cups.enums.http import HttpEncryption
@@ -23,7 +23,7 @@ def copyCredentialsKey(  # noqa: D103, N802
     is_key: bool = False,
     is_public_key: bool = False,
     copy_req: bool = False,
-) -> str:
+) -> str | bool | None:
     if (is_key and copy_req) or (is_public_key and copy_req):
         raise ValueError(  # noqa: TRY003
             "Cannot copy the key and the credentials request at the same time"
@@ -54,7 +54,7 @@ def copyDest(dest: cupsDest, dests: dict[str, cupsDest]) -> dict[str, cupsDest]:
     num_dests = _lib.cupsCopyDest(
         dest.ffi_value, len(dests), cupsDest.to_cffi_list(dests)
     )
-    return cupsDest.from_cffi_list(dests=dests, count=num_dests)
+    return cupsDest.from_cffi_list(dests=dests, count=num_dests)  # type: ignore[arg-type]
 
 
 def getEncryption() -> HttpEncryption:  # noqa: D103, N802
@@ -75,7 +75,7 @@ def setPort(port: int) -> None:  # noqa: D103, N802
     _lib.ippSetPort(port)
 
 
-def getServer() -> str:  # noqa: D103, N802
+def getServer() -> Optional[Union[str, bool]]:  # noqa: D103, N802
     return _bytes_to_value(_lib.cupsGetServer())
 
 
@@ -84,7 +84,7 @@ def setServer(server: str) -> None:  # noqa: D103, N802
     _lib.cupsSetServer(c_server)
 
 
-def getUser() -> str:  # noqa: D103, N802
+def getUser() -> Optional[Union[str, bool]]:  # noqa: D103, N802
     return _bytes_to_value(_lib.cupsGetUser())
 
 
@@ -99,7 +99,7 @@ def setDefaultDest(name: str, instance: str, num_dests: int, dest: cupsDest) -> 
     _lib.cupsSetDefaultDest(c_name, c_instance, num_dests, dest.ffi_value)
 
 
-def getUserAgent() -> str:  # noqa: D103, N802
+def getUserAgent() -> Optional[Union[str, bool]]:  # noqa: D103, N802
     return _bytes_to_value(_lib.cupsGetUserAgent())
 
 
@@ -114,11 +114,11 @@ def getDestWithURI(uri: str, name: Optional[str] = None) -> cupsDest:  # noqa: D
     dest = _lib.cupsGetDestWithURI(c_name, c_uri)
     if dest == _ffi.NULL:
         raise RuntimeError("No such destination found")  # noqa: TRY003
-    return cupsDest(ffi_value=dest)
+    return cupsDest(ffi_value=dest)  # type: ignore[call-arg]
 
 
 def getError() -> tuple[IPPStatus, Optional[str]]:  # noqa: D103, N802
     status: IPPStatus = IPPStatus(_lib.cupsGetError())
-    message: str = _bytes_to_value(_lib.cupsGetErrorString())
+    message: str = _bytes_to_value(_lib.cupsGetErrorString())  # type: ignore[assignment]
 
     return (status, message)

--- a/cups/generic.py
+++ b/cups/generic.py
@@ -1,21 +1,22 @@
+from pathlib import Path  # noqa: D100
+from typing import Optional
+
 from cups import _cups
 from cups.enums.http import HttpEncryption
 from cups.types.cups import cupsDest
 from cups.types.ipp import IPPStatus
 from cups.utils import _bytes_to_value, _value_to_bytes
-from typing import Dict, Optional, Tuple
-from pathlib import Path
 
 _ffi = _cups.ffi
 _lib = _cups.lib
 
 
-def areCredentialsValidForName(common_name: str, credentials: str) -> bool:
+def areCredentialsValidForName(common_name: str, credentials: str) -> bool:  # noqa: D103, N802
     ok = _lib.cupsAreCredentialsValidForName(common_name.encode(), credentials.encode())
     return bool(_bytes_to_value(ok))
 
 
-def copyCredentialsKey(
+def copyCredentialsKey(  # noqa: D103, N802
     path: Path,
     common_name: str,
     *,
@@ -24,7 +25,7 @@ def copyCredentialsKey(
     copy_req: bool = False,
 ) -> str:
     if (is_key and copy_req) or (is_public_key and copy_req):
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003
             "Cannot copy the key and the credentials request at the same time"
         )
 
@@ -48,77 +49,75 @@ def copyCredentialsKey(
     )
 
 
-def copyDest(dest: cupsDest, dests: Dict[str, cupsDest]) -> Dict[str, cupsDest]:
-    """
-    Returns a new list of dests
-    """
+def copyDest(dest: cupsDest, dests: dict[str, cupsDest]) -> dict[str, cupsDest]:  # noqa: N802
+    """Returns a new list of dests."""  # noqa: D401
     num_dests = _lib.cupsCopyDest(
         dest.ffi_value, len(dests), cupsDest.to_cffi_list(dests)
     )
     return cupsDest.from_cffi_list(dests=dests, count=num_dests)
 
 
-def getEncryption() -> HttpEncryption:
+def getEncryption() -> HttpEncryption:  # noqa: D103, N802
     encryption = _lib.cupsGetEncryption()
     return HttpEncryption(encryption)
 
 
-def setEncryption(encryption: HttpEncryption):
+def setEncryption(encryption: HttpEncryption) -> None:  # noqa: D103, N802
     c_encryption = _ffi.cast("http_encryption_t", encryption.value)
     _lib.cupsSetEncryption(c_encryption)
 
 
-def getPort() -> int:
+def getPort() -> int:  # noqa: D103, N802
     return _lib.ippGetPort()
 
 
-def setPort(port: int):
+def setPort(port: int) -> None:  # noqa: D103, N802
     _lib.ippSetPort(port)
 
 
-def getServer() -> str:
+def getServer() -> str:  # noqa: D103, N802
     return _bytes_to_value(_lib.cupsGetServer())
 
 
-def setServer(server: str):
+def setServer(server: str) -> None:  # noqa: D103, N802
     c_server = _ffi.new("char []", server)
     _lib.cupsSetServer(c_server)
 
 
-def getUser() -> str:
+def getUser() -> str:  # noqa: D103, N802
     return _bytes_to_value(_lib.cupsGetUser())
 
 
-def setUser(user: str):
+def setUser(user: str) -> None:  # noqa: D103, N802
     c_user = _ffi.new("char []", user)
     _lib.cupsSetUser(c_user)
 
 
-def setDefaultDest(name: str, instance: str, num_dests: int, dest: cupsDest):
+def setDefaultDest(name: str, instance: str, num_dests: int, dest: cupsDest) -> None:  # noqa: D103, N802
     c_name = _ffi.new("char[]", name.encode("utf-8")) if name else _ffi.NULL
     c_instance = _ffi.new("char[]", instance.encode("utf-8")) if instance else _ffi.NULL
     _lib.cupsSetDefaultDest(c_name, c_instance, num_dests, dest.ffi_value)
 
 
-def getUserAgent() -> str:
+def getUserAgent() -> str:  # noqa: D103, N802
     return _bytes_to_value(_lib.cupsGetUserAgent())
 
 
-def setUserAgent(user_agent: str):
+def setUserAgent(user_agent: str) -> None:  # noqa: D103, N802
     c_user_agent = _value_to_bytes(user_agent)
     _lib.cupsSetUserAgent(c_user_agent)
 
 
-def getDestWithURI(uri: str, name: Optional[str] = None) -> cupsDest:
+def getDestWithURI(uri: str, name: Optional[str] = None) -> cupsDest:  # noqa: D103, N802
     c_uri = _ffi.new("char[]", uri.encode("utf-8"))
     c_name = _ffi.new("char[]", name.encode("utf-8")) if name else _ffi.NULL
     dest = _lib.cupsGetDestWithURI(c_name, c_uri)
     if dest == _ffi.NULL:
-        raise RuntimeError("No such destination found")
+        raise RuntimeError("No such destination found")  # noqa: TRY003
     return cupsDest(ffi_value=dest)
 
 
-def getError() -> Tuple[IPPStatus, Optional[str]]:
+def getError() -> tuple[IPPStatus, Optional[str]]:  # noqa: D103, N802
     status: IPPStatus = IPPStatus(_lib.cupsGetError())
     message: str = _bytes_to_value(_lib.cupsGetErrorString())
 

--- a/cups/types/__init__.py
+++ b/cups/types/__init__.py
@@ -1,4 +1,4 @@
-from .cups import cupsDest, cupsJob, cupsOption
+from .cups import cupsDest, cupsJob, cupsOption  # noqa: A005, D104
 from .ipp import IPPAttribute, IPPRequest
 
 __all__ = [

--- a/cups/types/base.py
+++ b/cups/types/base.py
@@ -1,77 +1,75 @@
-from cups import _cups
-
+from abc import ABC  # noqa: D100
 from typing import Any, ClassVar
-from abc import ABC
+
+from cups import _cups
 
 _ffi = _cups.ffi
 _lib = _cups.lib
 
 
-class cupsBaseClass(ABC):
+class cupsBaseClass(ABC):  # noqa: D101, N801
     ffi_name: ClassVar[str]
     ffi_free: ClassVar[str]
     ffi_value: Any
 
-    def __init__(self, args=None):
+    def __init__(self, args=None) -> None:  # noqa: ANN001
         if args and self._is_valid_ctype(args):
             self.ffi_value = args
+        elif isinstance(args, str):
+            self.ffi_value = _ffi.new(f"{self.ffi_name} {args}")
         else:
-            if isinstance(args, str):
-                self.ffi_value = _ffi.new(f"{self.ffi_name} {args}")
-            else:
-                self.ffi_value = _ffi.new(f"{self.ffi_name} *")
+            self.ffi_value = _ffi.new(f"{self.ffi_name} *")
 
     # def __del__(self, extra_args: Optional[List] = None):
     #     if self.ffi_free:
-    #         cffi_free = getattr(_lib, self.ffi_free, None)
+    #         cffi_free = getattr(_lib, self.ffi_free, None)  # noqa: ERA001
     #         if cffi_free is None:
-    #             raise AttributeError(f"C function '{self.ffi_free}' not found in lib")
-    #         try:
-    #             cffi_free(*extra_args) if extra_args else cffi_free()
-    #         except Exception as e:
-    #             raise RuntimeError(f"Failed to call C function '{self.ffi_free}': {e}")
+    #             raise AttributeError(f"C function '{self.ffi_free}' not found in lib")  # noqa: ERA001
+    #         try:  # noqa: ERA001
+    #             cffi_free(*extra_args) if extra_args else cffi_free()  # noqa: ERA001
+    #         except Exception as e:  # noqa: ERA001
+    #             raise RuntimeError(f"Failed to call C function '{self.ffi_free}': {e}")  # noqa: ERA001
 
     # @classmethod
     # def cffi_free(cls, extra_args: Optional[List]):
     #     if not cls.ffi_free:
-    #         return
+    #         return  # noqa: ERA001
 
-    #     cffi_free = getattr(_lib, cls.ffi_free, None)
+    #     cffi_free = getattr(_lib, cls.ffi_free, None)  # noqa: ERA001
     #     if cffi_free is None:
-    #         raise AttributeError(f"C function '{cls.ffi_free}' not found in lib")
+    #         raise AttributeError(f"C function '{cls.ffi_free}' not found in lib")  # noqa: ERA001
 
-    #     try:
-    #         cffi_free(*extra_args) if extra_args else cffi_free()
-    #     except Exception as e:
-    #         raise RuntimeError(f"Failed to call C function '{cls.ffi_free}': {e}")
+    #     try:  # noqa: ERA001
+    #         cffi_free(*extra_args) if extra_args else cffi_free()  # noqa: ERA001
+    #     except Exception as e:  # noqa: ERA001
+    #         raise RuntimeError(f"Failed to call C function '{cls.ffi_free}': {e}")  # noqa: ERA001
 
     @property
-    def valid(self):
+    def valid(self):  # noqa: ANN201, D102
         return self._is_valid_ctype(self.ffi_value)
 
     @classmethod
-    def _is_valid_c_list(cls, ffi_value: Any) -> bool:
+    def _is_valid_c_list(cls, ffi_value: Any) -> bool:  # noqa: ANN401
         try:
             ctype = _ffi.typeof(ffi_value)
-            return ctype.item.kind == "pointer"
-        except:
+            return ctype.item.kind == "pointer"  # noqa: TRY300
+        except:  # noqa: E722
             return False
 
     @classmethod
-    def _is_valid_ctype(cls, ffi_value: Any) -> bool:
+    def _is_valid_ctype(cls, ffi_value: Any) -> bool:  # noqa: ANN401
         try:
             ctype = _ffi.typeof(ffi_value)
             ctype_name = _ffi.getctype(cls.ffi_name)
 
             if ctype.kind == "pointer":
                 return ctype.item.cname == ctype_name
-            else:
-                return ctype.cname == _ffi.getctype(cls.ffi_name)
-        except:
+            return ctype.cname == _ffi.getctype(cls.ffi_name)
+        except:  # noqa: E722
             return False
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__repr__()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}(ffi_value={self.ffi_value})"

--- a/cups/types/cups.py
+++ b/cups/types/cups.py
@@ -1,55 +1,60 @@
-from typing import (
+from typing import (  # noqa: D100
     Any,
     ClassVar,
-    Dict,
     Optional,
 )
 
+from cups.enums.ipp import IPPOp, IPPTag
+from cups.types.ipp import IPPAttribute, IPPRequest
 from cups.utils import (
     _bytes_to_value,
 )
 
-from cups.types.ipp import IPPAttribute, IPPRequest
-from cups.enums.ipp import IPPOp, IPPTag
-
-from .base import cupsBaseClass, _ffi, _lib
+from .base import _ffi, _lib, cupsBaseClass
 
 
-class cupsDestInfo(cupsBaseClass):
-    """A class representing a CUPS destination info"""
+class cupsDestInfo(cupsBaseClass):  # noqa: N801
+    """A class representing a CUPS destination info."""
 
     ffi_name: ClassVar[str] = "cups_dinfo_t"
 
 
-class cupsOption(cupsBaseClass):
+class cupsOption(cupsBaseClass):  # noqa: D101, N801
     @property
-    def name(self) -> str:
+    def name(self) -> str:  # noqa: D102
         return _bytes_to_value(self.ffi_value.name)
 
     @property
-    def value(self) -> Optional[Any]:
+    def value(self) -> Optional[Any]:  # noqa: ANN401, D102
         return _bytes_to_value(self.ffi_value.value)
 
     ffi_name = "cups_option_t"
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict:  # noqa: D102
         return {"name": self.name, "value": self.value}
 
-    def toAttribute(self, ipp_req: IPPRequest, group_tag: IPPTag) -> IPPAttribute:
+    def toAttribute(self, ipp_req: IPPRequest, group_tag: IPPTag) -> IPPAttribute:  # noqa: N802
         """Convert this cupsOption into an IPPAttribute.
+
         Args:
             ipp_req (IPPRequest): The IPPRequest to add the attribute to.
             group_tag (IPPTag): The group tag to use for the attribute.
 
         Returns:
             IPPAttribute: The created IPPAttribute.
+
         """
-
-        return IPPAttribute(_lib.cupsEncodeOption(ipp_req.ffi_value, group_tag, self.name.encode(), self.value.encode() if self.value else b""))
-
+        return IPPAttribute(
+            _lib.cupsEncodeOption(
+                ipp_req.ffi_value,
+                group_tag,
+                self.name.encode(),
+                self.value.encode() if self.value else b"",
+            )
+        )
 
     @classmethod
-    def to_cffi_list(cls, opts: "Dict[str, cupsOption]") -> Any:
+    def to_cffi_list(cls, opts: "dict[str, cupsOption]") -> Any:  # noqa: ANN401, D102
         count = len(opts)
         c_opts = _ffi.new(f"cups_option_t[{count}]")
 
@@ -63,17 +68,17 @@ class cupsOption(cupsBaseClass):
         return c_opts
 
     @classmethod
-    def from_cffi_list(cls, opts: Any, count: int) -> "Dict[str, cupsOption]":
-        """
-        Convert a list of CFFI dest structs to a list of python cupsOption.
+    def from_cffi_list(cls, opts: Any, count: int) -> "dict[str, cupsOption]":  # noqa: ANN401, D417
+        """Convert a list of CFFI dest structs to a list of python cupsOption.
 
         Args:
             dests (Any): The CFFI *cups_option_t pointer.
 
         Returns:
             List[cupsOption]: The list of cupsDest.
+
         """
-        results: Dict[str, cupsOption] = {}
+        results: dict[str, cupsOption] = {}
         for i in range(count):
             new_opt: Any = opts[i]
             results[str(_bytes_to_value(new_opt.name))] = cupsOption.from_cffi(
@@ -82,36 +87,35 @@ class cupsOption(cupsBaseClass):
 
         return results
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.name}: {self.value})"
 
 
-class cupsDest(cupsBaseClass):
+class cupsDest(cupsBaseClass):  # noqa: D101, N801
     @property
-    def name(self) -> str:
+    def name(self) -> str:  # noqa: D102
         return str(_bytes_to_value(self.ffi_value.name))
 
     @property
-    def instance(self) -> Optional[str]:
+    def instance(self) -> Optional[str]:  # noqa: D102
         return _bytes_to_value(self.ffi_value.instance)
 
     @property
-    def options(self) -> Dict[str, cupsOption]:
+    def options(self) -> dict[str, cupsOption]:  # noqa: D102
         return cupsOption.from_cffi_list(
             opts=self.ffi_value.options, count=self.ffi_value.num_options
         )
 
     @property
-    def is_default(self) -> bool:
+    def is_default(self) -> bool:  # noqa: D102
         return self.ffi_value.is_default
 
     ffi_name = "cups_dest_t"
     ffi_free = "cupsFreeDests"
 
     @classmethod
-    def from_cffi_list(cls, dests: "cupsDest", count: int) -> "Dict[str, cupsDest]":
-        """
-        Convert a list of CFFI dest structs to a list of python cupsDest.
+    def from_cffi_list(cls, dests: "cupsDest", count: int) -> "dict[str, cupsDest]":
+        """Convert a list of CFFI dest structs to a list of python cupsDest.
 
         Args:
             dests (Any): The CFFI *cups_dest_t pointer to a pointer.
@@ -119,8 +123,9 @@ class cupsDest(cupsBaseClass):
 
         Returns:
             Dict[str, cupsDest]: The list of cupsDest.
+
         """
-        results: Dict[str, cupsDest] = {}
+        results: dict[str, cupsDest] = {}
         for i in range(count):
             new_dest: Any = dests.ffi_value[0][i]
             results[str(_bytes_to_value(new_dest.name))] = cupsDest.from_cffi(
@@ -130,20 +135,20 @@ class cupsDest(cupsBaseClass):
         return results
 
     @classmethod
-    def from_cffi(cls, dest: Any) -> "cupsDest":
-        """
-        Convert a single CFFI dest struct to a Python cupsDest object.
+    def from_cffi(cls, dest: Any) -> "cupsDest":  # noqa: ANN401
+        """Convert a single CFFI dest struct to a Python cupsDest object.
 
         Args:
             dest (Any): The CFFI cups_dest_t struct.
 
         Returns:
             cupsDest: The equivalent Python object.
+
         """
         return cls(dest)
 
     @classmethod
-    def to_cffi_list(cls, dests: "Dict[str, cupsDest]") -> Any:
+    def to_cffi_list(cls, dests: "dict[str, cupsDest]") -> Any:  # noqa: ANN401, D102
         count = len(dests)
         c_dests = _ffi.new(f"cups_dest_t[{count}]")
 
@@ -161,10 +166,10 @@ class cupsDest(cupsBaseClass):
             return c_dests
         return None
 
-    def getPrinterAttributes(self, http: Any) -> dict[str, IPPAttribute]:
+    def getPrinterAttributes(self, http: Any) -> dict[str, IPPAttribute]:  # noqa: ANN401, D102, N802
         ctype = _ffi.typeof(http)
         if ctype.kind != "pointer" and ctype.cname != "struct _http_s *":
-            raise TypeError("http must be of type struct _http_s *")
+            raise TypeError("http must be of type struct _http_s *")  # noqa: TRY003
 
         req: IPPRequest = IPPRequest(IPPOp.GET_PRINTER_ATTRIBUTES)
         req.addString(
@@ -180,74 +185,75 @@ class cupsDest(cupsBaseClass):
                 for attr in res.attributes
                 if isinstance(attr, IPPAttribute)
             }
+        return None
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.name} (Default)" if self.is_default else self.name
 
 
-class cupsJob(cupsBaseClass):
+class cupsJob(cupsBaseClass):  # noqa: D101, N801
     ffi_name: ClassVar[str] = "cups_job_t"
     ffi_free: ClassVar[str] = "cupsFreeJobs"
 
     @property
-    def id(self) -> int:
+    def id(self) -> int:  # noqa: D102
         return self.ffi_value.id
 
     @property
-    def dest(self) -> str:
+    def dest(self) -> str:  # noqa: D102
         return str(_bytes_to_value(self.ffi_value.dest))
 
     @property
-    def title(self) -> Optional[str]:
+    def title(self) -> Optional[str]:  # noqa: D102
         return _bytes_to_value(self.ffi_value.title)
 
     @property
-    def user(self) -> Optional[str]:
+    def user(self) -> Optional[str]:  # noqa: D102
         return _bytes_to_value(self.ffi_value.user)
 
     @property
-    def format(self) -> Optional[str]:
+    def format(self) -> Optional[str]:  # noqa: D102
         return _bytes_to_value(self.ffi_value.format)
 
     @property
-    def state(self) -> int:
+    def state(self) -> int:  # noqa: D102
         return self.ffi_value.state
 
     @property
-    def size(self) -> int:
+    def size(self) -> int:  # noqa: D102
         return self.ffi_value.size
 
     @property
-    def priority(self) -> int:
+    def priority(self) -> int:  # noqa: D102
         return self.ffi_value.priority
 
     @property
-    def completed_time(self) -> int:
+    def completed_time(self) -> int:  # noqa: D102
         return self.ffi_value.completed_time
 
     @property
-    def creation_time(self) -> int:
+    def creation_time(self) -> int:  # noqa: D102
         return self.ffi_value.creation_time
 
     @property
-    def processing_time(self) -> int:
+    def processing_time(self) -> int:  # noqa: D102
         return self.ffi_value.processing_time
 
     @classmethod
-    def from_cffi(cls, job: Any) -> "cupsJob":
+    def from_cffi(cls, job: Any) -> "cupsJob":  # noqa: ANN401
         """Wrap a single cups_job_t struct in a cupsJob instance."""
         return cls(job)
 
     @classmethod
-    def from_cffi_list(cls, jobs: Any, count: int) -> Dict[int, "cupsJob"]:
+    def from_cffi_list(cls, jobs: Any, count: int) -> dict[int, "cupsJob"]:  # noqa: ANN401
         """Convert CFFI array of cups_job_t into a dict keyed by job ID."""
-        results: Dict[int, cupsJob] = {}
+        results: dict[int, cupsJob] = {}
         for i in range(count):
             new_job = jobs[i]
             results[new_job.id] = cls.from_cffi(new_job)
         return results
 
-    def to_cffi(self) -> Any:
+    def to_cffi(self) -> Any:  # noqa: ANN401
         """Convert this cupsJob instance into a CFFI cups_job_t struct."""
         c_job = _ffi.new(self.ffi_name + " *")
         c_job[0].id = self.id
@@ -269,8 +275,9 @@ class cupsJob(cupsBaseClass):
         c_job[0].processing_time = self.processing_time
         return c_job
 
-class cupsLang(cupsBaseClass):
+
+class cupsLang(cupsBaseClass):  # noqa: D101, N801
     ffi_name = "cups_lang_t"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return _bytes_to_value(_lib.cupsLangGetName(self.ffi_value))

--- a/cups/types/cups.py
+++ b/cups/types/cups.py
@@ -2,6 +2,8 @@ from typing import (  # noqa: D100
     Any,
     ClassVar,
     Optional,
+    Union,
+    cast,
 )
 
 from cups.enums.ipp import IPPOp, IPPTag
@@ -22,10 +24,10 @@ class cupsDestInfo(cupsBaseClass):  # noqa: N801
 class cupsOption(cupsBaseClass):  # noqa: D101, N801
     @property
     def name(self) -> str:  # noqa: D102
-        return _bytes_to_value(self.ffi_value.name)
+        return cast(str, _bytes_to_value(self.ffi_value.name))
 
     @property
-    def value(self) -> Optional[Any]:  # noqa: ANN401, D102
+    def value(self) -> Optional[Union[str, bool]]:  # noqa: D102
         return _bytes_to_value(self.ffi_value.value)
 
     ffi_name = "cups_option_t"
@@ -49,7 +51,7 @@ class cupsOption(cupsBaseClass):  # noqa: D101, N801
                 ipp_req.ffi_value,
                 group_tag,
                 self.name.encode(),
-                self.value.encode() if self.value else b"",
+                cast(str, self.value).encode() if self.value else b"",
             )
         )
 
@@ -81,7 +83,7 @@ class cupsOption(cupsBaseClass):  # noqa: D101, N801
         results: dict[str, cupsOption] = {}
         for i in range(count):
             new_opt: Any = opts[i]
-            results[str(_bytes_to_value(new_opt.name))] = cupsOption.from_cffi(
+            results[str(_bytes_to_value(new_opt.name))] = cupsOption.from_cffi(  # type: ignore[attr-defined]
                 opt=new_opt
             )
 
@@ -98,7 +100,7 @@ class cupsDest(cupsBaseClass):  # noqa: D101, N801
 
     @property
     def instance(self) -> Optional[str]:  # noqa: D102
-        return _bytes_to_value(self.ffi_value.instance)
+        return _bytes_to_value(self.ffi_value.instance)  # type: ignore[return-value]
 
     @property
     def options(self) -> dict[str, cupsOption]:  # noqa: D102
@@ -176,7 +178,7 @@ class cupsDest(cupsBaseClass):  # noqa: D101, N801
             group=IPPTag.OPERATION,
             value_tag=IPPTag.URI,
             name="printer-uri",
-            value=self.options["printer-uri-supported"].value,
+            value=self.options["printer-uri-supported"].value,  # type: ignore[arg-type]
         )
         res: IPPRequest = IPPRequest(_lib.cupsDoRequest(http, req.ffi_value, b"/"))
         if res is not None:
@@ -205,15 +207,15 @@ class cupsJob(cupsBaseClass):  # noqa: D101, N801
 
     @property
     def title(self) -> Optional[str]:  # noqa: D102
-        return _bytes_to_value(self.ffi_value.title)
+        return _bytes_to_value(self.ffi_value.title)  # type: ignore[return-value]
 
     @property
     def user(self) -> Optional[str]:  # noqa: D102
-        return _bytes_to_value(self.ffi_value.user)
+        return _bytes_to_value(self.ffi_value.user)  # type: ignore[return-value]
 
     @property
     def format(self) -> Optional[str]:  # noqa: D102
-        return _bytes_to_value(self.ffi_value.format)
+        return _bytes_to_value(self.ffi_value.format)  # type: ignore[return-value]
 
     @property
     def state(self) -> int:  # noqa: D102
@@ -280,4 +282,4 @@ class cupsLang(cupsBaseClass):  # noqa: D101, N801
     ffi_name = "cups_lang_t"
 
     def __str__(self) -> str:
-        return _bytes_to_value(_lib.cupsLangGetName(self.ffi_value))
+        return _bytes_to_value(_lib.cupsLangGetName(self.ffi_value))  # type: ignore[return-value]

--- a/cups/types/ipp.py
+++ b/cups/types/ipp.py
@@ -160,7 +160,7 @@ class IPPRequest(cupsBaseClass):  # noqa: D101
         if group is None or value_tag is None or name is None or value is None:
             raise RuntimeError("Invalid parameters passed")  # noqa: TRY003
 
-        language = _ffi.NULL if language is None else language.encode()
+        language = _ffi.NULL if language is None else language.encode()  # type: ignore[assignment]
 
         return IPPAttribute(
             _lib.ippAddString(
@@ -184,7 +184,7 @@ class IPPRequest(cupsBaseClass):  # noqa: D101
         if group is None or value_tag is None or name is None or values is None:
             raise RuntimeError("Invalid parameters passed")  # noqa: TRY003
 
-        language = _ffi.NULL if language is None else language.encode()
+        language = _ffi.NULL if language is None else language.encode()  # type: ignore[assignment]
 
         c_array = _ffi.new("char *[]", len(values))
         for i, value in enumerate(values):
@@ -233,7 +233,7 @@ class IPPError(Exception):
         return self._response.statuscode
 
     @property
-    def message(self) -> str:  # noqa: D102
+    def message(self) -> Optional[Union[str, bool]]:  # noqa: D102
         return _bytes_to_value(_lib.ippGetErrorString(self.status))
 
     @override

--- a/cups/types/ipp.py
+++ b/cups/types/ipp.py
@@ -1,13 +1,15 @@
-from .base import cupsBaseClass, _lib, _ffi
-from cups.utils import _bytes_to_value
-from typing import Any, ClassVar, override, Optional, Union
+import struct  # noqa: D100
 from dataclasses import dataclass, field
-from cups.enums.ipp import IPPRes, IPPState, IPPStatus, IPPTag, IPPOp
 from datetime import datetime
-import struct
+from typing import Any, ClassVar, Optional, Union, override
+
+from cups.enums.ipp import IPPOp, IPPRes, IPPState, IPPStatus, IPPTag
+from cups.utils import _bytes_to_value
+
+from .base import _ffi, _lib, cupsBaseClass
 
 
-class IPPAttribute(cupsBaseClass):
+class IPPAttribute(cupsBaseClass):  # noqa: D101
     ffi_name: ClassVar[str] = "ipp_attribute_t"
     """
     https://openprinting.github.io/cups/libcups/cupspm.html#ippDeleteAttribute
@@ -17,26 +19,26 @@ class IPPAttribute(cupsBaseClass):
     ffi_free: ClassVar[str] = "ippDeleteAttributes"
 
     @property
-    def name(self) -> str:
+    def name(self) -> str:  # noqa: D102
         c_name = _lib.ippGetName(self.ffi_value)
         if c_name == _ffi.NULL:
             return ""
         return str(_bytes_to_value(c_name))
 
     @property
-    def group_tag(self) -> int:
+    def group_tag(self) -> int:  # noqa: D102
         return _lib.ippGetGroupTag(self.ffi_value)
 
     @property
-    def value_tag(self) -> IPPTag:
+    def value_tag(self) -> IPPTag:  # noqa: D102
         return IPPTag(_lib.ippGetValueTag(self.ffi_value))
 
     @property
-    def count(self) -> int:
+    def count(self) -> int:  # noqa: D102
         return _lib.ippGetCount(self.ffi_value)
 
     @property
-    def values(self) -> list[Any]:
+    def values(self) -> list[Any]:  # noqa: D102, PLR0911
         if self.value_tag in [
             IPPTag.ZERO,
             IPPTag.NOVALUE,
@@ -53,7 +55,7 @@ class IPPAttribute(cupsBaseClass):
             return ranges
         if self.value_tag in [IPPTag.INTEGER, IPPTag.ENUM]:
             return [_lib.ippGetInteger(self.ffi_value, i) for i in range(self.count)]
-        elif self.value_tag in [
+        if self.value_tag in [
             IPPTag.TEXT,
             IPPTag.NAME,
             IPPTag.KEYWORD,
@@ -66,15 +68,15 @@ class IPPAttribute(cupsBaseClass):
                 _bytes_to_value(_lib.ippGetString(self.ffi_value, i, _ffi.NULL))
                 for i in range(self.count)
             ]
-        elif self.value_tag == IPPTag.BOOLEAN:
+        if self.value_tag == IPPTag.BOOLEAN:
             return [_lib.ippGetBoolean(self.ffi_value, i) for i in range(self.count)]
-        elif self.value_tag == IPPTag.DATE:
+        if self.value_tag == IPPTag.DATE:
             dates: list[datetime] = []
             for i in range(self.count):
                 date_hex_bytes: bytes = _ffi.string(_lib.ippGetDate(self.ffi_value, i))
                 dates.append(datetime(*struct.unpack(">H5B", date_hex_bytes)))
             return dates
-        elif self.value_tag == IPPTag.RESOLUTION:
+        if self.value_tag == IPPTag.RESOLUTION:
             resolutions = []
             for i in range(self.count):
                 unit = _ffi.new("ipp_res_t *")
@@ -82,26 +84,25 @@ class IPPAttribute(cupsBaseClass):
                 _lib.ippGetResolution(self.ffi_value, i, res, unit)
                 resolutions.append((res[0], IPPRes(unit[0])))
             return resolutions
-        elif self.value_tag == IPPTag.BEGIN_COLLECTION:
+        if self.value_tag == IPPTag.BEGIN_COLLECTION:
             collections = []
             for i in range(self.count):
                 attr = IPPRequest(_lib.ippGetCollection(self.ffi_value, i))
                 collections.append(attr)
             return collections
-        else:
-            return []
+        return []
 
-    def __str__(self):
+    def __str__(self) -> str:
         required_size = _lib.ippAttributeString(self.ffi_value, _ffi.NULL, 0) + 1
         buffer = _ffi.new("char[]", required_size)
         _lib.ippAttributeString(self.ffi_value, buffer, required_size)
         return str(_bytes_to_value(buffer))
 
 
-class IPPRequest(cupsBaseClass):
+class IPPRequest(cupsBaseClass):  # noqa: D101
     ffi_name: ClassVar[str] = "ipp_t"
 
-    def __init__(self, arg: Optional[Union[IPPOp, Any]] = None):
+    def __init__(self, arg: Optional[Union[IPPOp, Any]] = None) -> None:  # noqa: ANN401
         if isinstance(arg, IPPOp):
             self.ffi_value = _lib.ippNewRequest(arg)
 
@@ -112,10 +113,10 @@ class IPPRequest(cupsBaseClass):
             self.ffi_value = _lib.ippNew()
 
         else:
-            raise ValueError("Invalid arguments passed")
+            raise ValueError("Invalid arguments passed")  # noqa: TRY003
 
     @property
-    def attributes(self) -> list[IPPAttribute]:
+    def attributes(self) -> list[IPPAttribute]:  # noqa: D102
         attrs: list[IPPAttribute] = []
         attr = _lib.ippGetFirstAttribute(self.ffi_value)
         while attr != _ffi.NULL:
@@ -124,23 +125,23 @@ class IPPRequest(cupsBaseClass):
         return attrs
 
     @property
-    def operation(self) -> IPPOp:
+    def operation(self) -> IPPOp:  # noqa: D102
         return IPPOp(_lib.ippGetOperation(self.ffi_value))
 
     @property
-    def state(self) -> IPPState:
+    def state(self) -> IPPState:  # noqa: D102
         return IPPState(_lib.ippGetState(self.ffi_value))
 
     @property
-    def statuscode(self) -> IPPStatus:
+    def statuscode(self) -> IPPStatus:  # noqa: D102
         return IPPStatus(_lib.ippGetStatusCode(self.ffi_value))
 
     @property
-    def request_id(self) -> int:
+    def request_id(self) -> int:  # noqa: D102
         return _lib.ippGetRequestId(self.ffi_value)
 
     @property
-    def version(self) -> float:
+    def version(self) -> float:  # noqa: D102
         minor = _ffi.new("int *")
         major = _lib.ippGetVersion(self.ffi_value, minor)
         return float(f"{major}.{minor[0]}")
@@ -148,7 +149,7 @@ class IPPRequest(cupsBaseClass):
     def __len__(self) -> int:
         return _lib.ippGetLength(self.ffi_value)
 
-    def addString(
+    def addString(  # noqa: D102, N802
         self,
         group: IPPTag,
         value_tag: IPPTag,
@@ -157,7 +158,7 @@ class IPPRequest(cupsBaseClass):
         language: Optional[str] = None,
     ) -> IPPAttribute:
         if group is None or value_tag is None or name is None or value is None:
-            raise RuntimeError("Invalid parameters passed")
+            raise RuntimeError("Invalid parameters passed")  # noqa: TRY003
 
         language = _ffi.NULL if language is None else language.encode()
 
@@ -172,7 +173,7 @@ class IPPRequest(cupsBaseClass):
             )
         )
 
-    def addStrings(
+    def addStrings(  # noqa: ANN201, D102, N802
         self,
         group: IPPTag,
         value_tag: IPPTag,
@@ -181,7 +182,7 @@ class IPPRequest(cupsBaseClass):
         language: Optional[str] = None,
     ):
         if group is None or value_tag is None or name is None or values is None:
-            raise RuntimeError("Invalid parameters passed")
+            raise RuntimeError("Invalid parameters passed")  # noqa: TRY003
 
         language = _ffi.NULL if language is None else language.encode()
 
@@ -201,42 +202,40 @@ class IPPRequest(cupsBaseClass):
             )
         )
 
-    def setString(
+    def setString(  # noqa: ANN201, D102, N802
         self,
         attr: IPPAttribute,
         position: int,
         value: str,
     ):
         if attr is None or position < 0 or value is None:
-            raise RuntimeError("Invalid parameters passed")
+            raise RuntimeError("Invalid parameters passed")  # noqa: TRY003
 
         return IPPAttribute(
             _lib.ippSetString(self.ffi_value, attr.ffi_value, position, value.encode())
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.__class__.__name__}(state={self.state})"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}(state={self.state}, statuscode={self.statuscode}, version={self.version})"
 
 
 @dataclass
 class IPPError(Exception):
-    """
-    Exception for IPP/CUPS request errors.
-    """
+    """Exception for IPP/CUPS request errors."""
 
     _response: IPPRequest = field(repr=False)
 
     @property
-    def status(self) -> IPPStatus:
+    def status(self) -> IPPStatus:  # noqa: D102
         return self._response.statuscode
 
     @property
-    def message(self) -> str:
+    def message(self) -> str:  # noqa: D102
         return _bytes_to_value(_lib.ippGetErrorString(self.status))
 
     @override
-    def __str__(self):
+    def __str__(self) -> str:
         return f"IPP Error {self.status.value} ({self.status.name}): {self.message}"

--- a/cups/types/media.py
+++ b/cups/types/media.py
@@ -32,16 +32,16 @@ class cupsMedia(cupsBaseClass):  # noqa: D101, N801
 
     @property
     def media(self) -> str:  # noqa: D102
-        return _bytes_to_value(self.ffi_value.media)
+        return _bytes_to_value(self.ffi_value.media)  # type: ignore[return-value]
 
     @property
     def color(self) -> int:  # noqa: D102
-        return _bytes_to_value(self.ffi_value.color)
+        return _bytes_to_value(self.ffi_value.color)  # type: ignore[return-value]
 
     @property
     def source(self) -> str:  # noqa: D102
-        return _bytes_to_value(self.ffi_value.source)
+        return _bytes_to_value(self.ffi_value.source)  # type: ignore[return-value]
 
     @property
     def type(self) -> str:  # noqa: D102
-        return _bytes_to_value(self.ffi_value.type)
+        return _bytes_to_value(self.ffi_value.type)  # type: ignore[return-value]

--- a/cups/types/media.py
+++ b/cups/types/media.py
@@ -1,46 +1,47 @@
+from cups.utils import _bytes_to_value  # noqa: D100
+
 from .base import cupsBaseClass
-from cups.utils import _bytes_to_value
 
 
-class cupsMedia(cupsBaseClass):
+class cupsMedia(cupsBaseClass):  # noqa: D101, N801
     ffi_name = "cups_media_t"
 
     @property
-    def width(self) -> int:
+    def width(self) -> int:  # noqa: D102
         return self.ffi_value.width
 
     @property
-    def length(self) -> int:
+    def length(self) -> int:  # noqa: D102
         return self.ffi_value.length
 
     @property
-    def bottom(self) -> int:
+    def bottom(self) -> int:  # noqa: D102
         return self.ffi_value.bottom_margin
 
     @property
-    def left(self) -> int:
+    def left(self) -> int:  # noqa: D102
         return self.ffi_value.left_margin
 
     @property
-    def right(self) -> int:
+    def right(self) -> int:  # noqa: D102
         return self.ffi_value.right_margin
 
     @property
-    def top(self) -> int:
+    def top(self) -> int:  # noqa: D102
         return self.ffi_value.top_margin
 
     @property
-    def media(self) -> str:
+    def media(self) -> str:  # noqa: D102
         return _bytes_to_value(self.ffi_value.media)
 
     @property
-    def color(self) -> int:
+    def color(self) -> int:  # noqa: D102
         return _bytes_to_value(self.ffi_value.color)
 
     @property
-    def source(self) -> str:
+    def source(self) -> str:  # noqa: D102
         return _bytes_to_value(self.ffi_value.source)
 
     @property
-    def type(self) -> str:
+    def type(self) -> str:  # noqa: D102
         return _bytes_to_value(self.ffi_value.type)

--- a/cups/utils.py
+++ b/cups/utils.py
@@ -1,5 +1,6 @@
+from typing import Any, Optional, Union  # noqa: D100
+
 from cups import _cups
-from typing import Any, Optional, Union
 
 _ffi = _cups.ffi
 
@@ -14,10 +15,9 @@ def _strtobool(val: str) -> Optional[bool]:
     val = val.lower().strip()
     if val in ("y", "yes", "t", "true", "on", "1"):
         return True
-    elif val in ("n", "no", "f", "false", "off", "0"):
+    if val in ("n", "no", "f", "false", "off", "0"):
         return False
-    else:
-        return None
+    return None
 
 
 def _bytes_to_value(b: bytes) -> Optional[Union[str, bool]]:
@@ -32,10 +32,11 @@ def _bytes_to_value(b: bytes) -> Optional[Union[str, bool]]:
     return None
 
 
-def _value_to_bytes(value: Optional[Union[list, str]]) -> Any:
+def _value_to_bytes(value: Optional[Union[list, str]]) -> Any:  # noqa: ANN401
     if value is None:
         return _ffi.NULL
     if isinstance(value, list):
         return _ffi.new("char *[]", [_ffi.new("char[]", s.encode()) for s in value])
     if isinstance(value, str):
         return _ffi.new("char[]", value.encode())
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,14 @@ authors = [
 readme = "README.md"
 dependencies = [
     "cffi>=1.17.1",
+    "pkgconfig>=1.5",
 ]
 classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: POSIX :: Linux",
         "Topic :: Software Development :: Libraries",
 ]
+requires-python = ">=3.9"
 
 [build-system]
 requires = [
@@ -23,3 +25,117 @@ requires = [
     "pkgconfig>=1.5.5"
 ]
 build-backend = "setuptools.build_meta"
+
+[dependency-groups]
+lint = [
+    "mypy~=1.17",
+    "types-cffi~=1.17",
+    "types-setuptools>=42",
+]
+
+[tool.ruff]
+line-length = 88
+target-version = "py39"
+src = ["cups"]
+
+[tool.ruff.format]
+docstring-code-format = true
+line-ending = "lf"
+quote-style = "double"
+
+[tool.ruff.lint]
+# Handy link: https://docs.astral.sh/ruff/rules/
+select = [ # Base linting rule selections.
+    # All sections here are stable in ruff and shouldn't randomly introduce failures with ruff updates.
+    "F",     # The rules built into Flake8
+    "E",
+    "W",     # pycodestyle errors and warnings
+    "I",     # isort checking
+    "N",     # PEP8 naming
+    "D",     # Implement pydocstyle checking as well.
+    "UP",    # Pyupgrade - note that some of are excluded below due to Python versions
+    "YTT",   # flake8-2020: Misuse of `sys.version` and `sys.version_info`
+    "ANN",   # Type annotations.
+    "ASYNC", # Catching blocking calls in async functions
+    # flake8-bandit: security testing. https://docs.astral.sh/ruff/rules/#flake8-bandit-s
+    # https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing
+    "S101",
+    "S102", # assert or exec
+    "S103",
+    "S108", # File permissions and tempfiles - use #noqa to silence when appropriate.
+    "S104", # Network binds
+    "S105",
+    "S106",
+    "S107", # Hardcoded passwords
+    "S110", # try-except-pass (use contextlib.suppress instead)
+    "S113", # Requests calls without timeouts
+    "S3",   # Serialising, deserialising, hashing, crypto, etc.
+    "S5",   # Unsafe cryptography or YAML loading.
+    "S602", # Subprocess call with shell=true
+    "S701", # jinja2 templates without autoescape
+    "BLE",  # Do not catch blind exceptions
+    "FBT",  # Disallow boolean positional arguments (make them keyword-only)
+    "B0",   # Common mistakes and typos.
+    "A",    # Shadowing built-ins.
+    "COM",  # Trailing commas
+    "C4",   # Encourage comprehensions, which tend to be faster than alternatives.
+    "T10",  # Don't call the debugger in production code
+    "ISC",  # Implicit string concatenation that can cause subtle issues
+    "ICN",  # Only use common conventions for import aliases.
+    "INP",  # Implicit namespace packages
+    # flake8-pie: miscellaneous linters (enabled individually because they're not really related)
+    "PIE790", # Unnecessary pass statement
+    "PIE794", # Multiple definitions of class field
+    "PIE796", # Duplicate value in an enum (reasonable to noqa for backwards compatibility)
+    "PIE804", # Don't use a dict with unnecessary kwargs
+    "PIE807", # prefer `list` over `lambda: []`
+    "PIE810", # Use a tuple rather than multiple calls. E.g. `mystr.startswith(("Hi", "Hello"))`
+    "PYI",    # Linting for type stubs.
+    "PT",     # Pytest
+    "Q",      # Consistent quotations
+    "RSE",    # Errors on pytest raises.
+    "RET",    # Simpler logic after return, raise, continue or break
+    "SLF",    # Prevent accessing private class members.
+    "SIM",    # Code simplification
+    "TID",    # Tidy imports
+    "TC001",  # Checks for first-party imports that are only used for type annotations
+    "TC002",  # Checks for third-party imports that are only used for type annotations
+    "TC003",  # Checks for standard library imports that are only used for type annotations
+    "TC004",  # Remove imports from type-checking guard blocks if used at runtime
+    "TC005",  # Delete empty type-checking blocks
+    "ARG",    # Unused arguments
+    "PTH",    # Migrate to pathlib
+    "FIX",    # All TODOs, FIXMEs, etc. should be turned into issues instead.
+    "ERA",    # Don't check in commented out code
+    "PGH",    # Pygrep hooks
+    "PL",     # Pylint
+    "TRY",    # Cleaner try/except,
+    "FLY",    # Detect things that would be better as f-strings.
+    "PERF",   # Catch things that can slow down the application like unnecessary casts to list.
+    "RUF001",
+    "RUF002",
+    "RUF003", # Ambiguous unicode characters
+    "RUF005", # Encourages unpacking rather than concatenation
+    "RUF008", # Do not use mutable default values for dataclass attributes
+    "B035",   # Don't use static keys in dict comprehensions.
+    "RUF013", # Prohibit implicit Optionals (PEP 484)
+    "RUF100", # #noqa directive that doesn't flag anything
+    "RUF200", # If ruff fails to parse pyproject.toml...
+]
+ignore = [
+    "E501",   # Line too long (reason: ruff will automatically fix this for us)
+    "D105",   # Missing docstring in magic method (reason: magic methods already have definitions)
+    "D107",   # Missing docstring in __init__ (reason: documented in class docstring)
+    "D203",   # 1 blank line required before class docstring (reason: pep257 default)
+    "D213",   # Multi-line docstring summary should start at the second line (reason: pep257 default)
+    "D215",   # Section underline is over-indented (reason: pep257 default)
+    "A003",   # Class attribute shadowing built-in (reason: Class attributes don't often get bare references)
+    "SIM117", # Use a single `with` statement with multiple contexts instead of nested `with` statements
+    # (reason: this creates long lines that get wrapped and reduces readability)
+    "PLW1641", # eq-without-hash (most of our classes should be unhashable)
+
+    # Ignored due to conflicts with ruff's formatter:
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "COM812", # Missing trailing comma - mostly the same, but marginal differences.
+    "ISC001", # Single-line implicit string concatenation.
+]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup  # noqa: D100
 
 setup(
     cffi_modules=["cups/build_cups.py:ffibuilder"],

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup  # noqa: D100
+from setuptools import setup  # type: ignore[reportMissingModuleSource]  # noqa: D100
 
 setup(
     cffi_modules=["cups/build_cups.py:ffibuilder"],

--- a/test/test.py
+++ b/test/test.py
@@ -1,14 +1,16 @@
 import cups  # noqa: D100, INP001
 
-dests = cups.getDests()
+dests = cups.getDests()  # type: ignore[reportAttributeAccessIssue]
 
 for dest in dests:
     _dest = dests[dest]
-    print(f"Name: {_dest.name}\nInstance: {_dest.instance}\nIs Default: {_dest.is_default}")
+    print(
+        f"Name: {_dest.name}\nInstance: {_dest.instance}\nIs Default: {_dest.is_default}"
+    )
     for option in _dest.options:
         _option = _dest.options[option]
         print(f"{_option.name}:  {_option.value}")
 
 key_0 = list(dests.keys())[0]
 
-print(cups.getOption('printer-uri-supported', dests[key_0].options))  # noqa: Q000
+print(cups.getOption("printer-uri-supported", dests[key_0].options))  # type: ignore[reportAttributeAccessIssue]

--- a/test/test.py
+++ b/test/test.py
@@ -1,4 +1,4 @@
-import cups
+import cups  # noqa: D100, INP001
 
 dests = cups.getDests()
 
@@ -11,4 +11,4 @@ for dest in dests:
 
 key_0 = list(dests.keys())[0]
 
-print(cups.getOption('printer-uri-supported', dests[key_0].options))
+print(cups.getOption('printer-uri-supported', dests[key_0].options))  # noqa: Q000

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,282 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/08ed5a43f2996a16b462f64a7055c6e962803534924b9b2f1371d8c00b7b/cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf", size = 184288, upload-time = "2025-09-08T23:23:48.404Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/de/38d9726324e127f727b4ecc376bc85e505bfe61ef130eaf3f290c6847dd4/cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7", size = 180509, upload-time = "2025-09-08T23:23:49.73Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/13/c92e36358fbcc39cf0962e83223c9522154ee8630e1df7c0b3a39a8124e2/cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c", size = 208813, upload-time = "2025-09-08T23:23:51.263Z" },
+    { url = "https://files.pythonhosted.org/packages/15/12/a7a79bd0df4c3bff744b2d7e52cc1b68d5e7e427b384252c42366dc1ecbc/cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165", size = 216498, upload-time = "2025-09-08T23:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ad/5c51c1c7600bdd7ed9a24a203ec255dccdd0ebf4527f7b922a0bde2fb6ed/cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534", size = 203243, upload-time = "2025-09-08T23:23:53.836Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f2/81b63e288295928739d715d00952c8c6034cb6c6a516b17d37e0c8be5600/cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f", size = 203158, upload-time = "2025-09-08T23:23:55.169Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/74/cc4096ce66f5939042ae094e2e96f53426a979864aa1f96a621ad128be27/cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63", size = 216548, upload-time = "2025-09-08T23:23:56.506Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/be/f6424d1dc46b1091ffcc8964fa7c0ab0cd36839dd2761b49c90481a6ba1b/cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2", size = 218897, upload-time = "2025-09-08T23:23:57.825Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e0/dda537c2309817edf60109e39265f24f24aa7f050767e22c98c53fe7f48b/cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65", size = 211249, upload-time = "2025-09-08T23:23:59.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e7/7c769804eb75e4c4b35e658dba01de1640a351a9653c3d49ca89d16ccc91/cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322", size = 218041, upload-time = "2025-09-08T23:24:00.496Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d9/6218d78f920dcd7507fc16a766b5ef8f3b913cc7aa938e7fc80b9978d089/cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a", size = 172138, upload-time = "2025-09-08T23:24:01.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/8f/a1e836f82d8e32a97e6b29cc8f641779181ac7363734f12df27db803ebda/cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9", size = 182794, upload-time = "2025-09-08T23:24:02.943Z" },
+]
+
+[[package]]
+name = "cups"
+version = "3.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "cffi" },
+    { name = "pkgconfig" },
+]
+
+[package.dev-dependencies]
+lint = [
+    { name = "mypy" },
+    { name = "types-cffi" },
+    { name = "types-setuptools" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cffi", specifier = ">=1.17.1" },
+    { name = "pkgconfig", specifier = ">=1.5" },
+]
+
+[package.metadata.requires-dev]
+lint = [
+    { name = "mypy", specifier = "~=1.17" },
+    { name = "types-cffi", specifier = "~=1.17" },
+    { name = "types-setuptools", specifier = ">=42" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/ea637422dedf0bf36f3ef238eab4e455e2a0dcc3082b5cc067615347ab8e/mypy-1.17.1.tar.gz", hash = "sha256:25e01ec741ab5bb3eec8ba9cdb0f769230368a22c959c4937360efb89b7e9f01", size = 3352570, upload-time = "2025-07-31T07:54:19.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/a9/3d7aa83955617cdf02f94e50aab5c830d205cfa4320cf124ff64acce3a8e/mypy-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3fbe6d5555bf608c47203baa3e72dbc6ec9965b3d7c318aa9a4ca76f465bd972", size = 11003299, upload-time = "2025-07-31T07:54:06.425Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e8/72e62ff837dd5caaac2b4a5c07ce769c8e808a00a65e5d8f94ea9c6f20ab/mypy-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:80ef5c058b7bce08c83cac668158cb7edea692e458d21098c7d3bce35a5d43e7", size = 10125451, upload-time = "2025-07-31T07:53:52.974Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/10/f3f3543f6448db11881776f26a0ed079865926b0c841818ee22de2c6bbab/mypy-1.17.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4a580f8a70c69e4a75587bd925d298434057fe2a428faaf927ffe6e4b9a98df", size = 11916211, upload-time = "2025-07-31T07:53:18.879Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bf/63e83ed551282d67bb3f7fea2cd5561b08d2bb6eb287c096539feb5ddbc5/mypy-1.17.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd86bb649299f09d987a2eebb4d52d10603224500792e1bee18303bbcc1ce390", size = 12652687, upload-time = "2025-07-31T07:53:30.544Z" },
+    { url = "https://files.pythonhosted.org/packages/69/66/68f2eeef11facf597143e85b694a161868b3b006a5fbad50e09ea117ef24/mypy-1.17.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a76906f26bd8d51ea9504966a9c25419f2e668f012e0bdf3da4ea1526c534d94", size = 12896322, upload-time = "2025-07-31T07:53:50.74Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/87/8e3e9c2c8bd0d7e071a89c71be28ad088aaecbadf0454f46a540bda7bca6/mypy-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:e79311f2d904ccb59787477b7bd5d26f3347789c06fcd7656fa500875290264b", size = 9507962, upload-time = "2025-07-31T07:53:08.431Z" },
+    { url = "https://files.pythonhosted.org/packages/46/cf/eadc80c4e0a70db1c08921dcc220357ba8ab2faecb4392e3cebeb10edbfa/mypy-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ad37544be07c5d7fba814eb370e006df58fed8ad1ef33ed1649cb1889ba6ff58", size = 10921009, upload-time = "2025-07-31T07:53:23.037Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c1/c869d8c067829ad30d9bdae051046561552516cfb3a14f7f0347b7d973ee/mypy-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:064e2ff508e5464b4bd807a7c1625bc5047c5022b85c70f030680e18f37273a5", size = 10047482, upload-time = "2025-07-31T07:53:26.151Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b9/803672bab3fe03cee2e14786ca056efda4bb511ea02dadcedde6176d06d0/mypy-1.17.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70401bbabd2fa1aa7c43bb358f54037baf0586f41e83b0ae67dd0534fc64edfd", size = 11832883, upload-time = "2025-07-31T07:53:47.948Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fb/fcdac695beca66800918c18697b48833a9a6701de288452b6715a98cfee1/mypy-1.17.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e92bdc656b7757c438660f775f872a669b8ff374edc4d18277d86b63edba6b8b", size = 12566215, upload-time = "2025-07-31T07:54:04.031Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/a932da3d3dace99ee8eb2043b6ab03b6768c36eb29a02f98f46c18c0da0e/mypy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c1fdf4abb29ed1cb091cf432979e162c208a5ac676ce35010373ff29247bcad5", size = 12751956, upload-time = "2025-07-31T07:53:36.263Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/6438a429e0f2f5cab8bc83e53dbebfa666476f40ee322e13cac5e64b79e7/mypy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:ff2933428516ab63f961644bc49bc4cbe42bbffb2cd3b71cc7277c07d16b1a8b", size = 9507307, upload-time = "2025-07-31T07:53:59.734Z" },
+    { url = "https://files.pythonhosted.org/packages/17/a2/7034d0d61af8098ec47902108553122baa0f438df8a713be860f7407c9e6/mypy-1.17.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:69e83ea6553a3ba79c08c6e15dbd9bfa912ec1e493bf75489ef93beb65209aeb", size = 11086295, upload-time = "2025-07-31T07:53:28.124Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1f/19e7e44b594d4b12f6ba8064dbe136505cec813549ca3e5191e40b1d3cc2/mypy-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b16708a66d38abb1e6b5702f5c2c87e133289da36f6a1d15f6a5221085c6403", size = 10112355, upload-time = "2025-07-31T07:53:21.121Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/69/baa33927e29e6b4c55d798a9d44db5d394072eef2bdc18c3e2048c9ed1e9/mypy-1.17.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89e972c0035e9e05823907ad5398c5a73b9f47a002b22359b177d40bdaee7056", size = 11875285, upload-time = "2025-07-31T07:53:55.293Z" },
+    { url = "https://files.pythonhosted.org/packages/90/13/f3a89c76b0a41e19490b01e7069713a30949d9a6c147289ee1521bcea245/mypy-1.17.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03b6d0ed2b188e35ee6d5c36b5580cffd6da23319991c49ab5556c023ccf1341", size = 12737895, upload-time = "2025-07-31T07:53:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a1/c4ee79ac484241301564072e6476c5a5be2590bc2e7bfd28220033d2ef8f/mypy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c837b896b37cd103570d776bda106eabb8737aa6dd4f248451aecf53030cdbeb", size = 12931025, upload-time = "2025-07-31T07:54:17.125Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b8/7409477be7919a0608900e6320b155c72caab4fef46427c5cc75f85edadd/mypy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:665afab0963a4b39dff7c1fa563cc8b11ecff7910206db4b2e64dd1ba25aed19", size = 9584664, upload-time = "2025-07-31T07:54:12.842Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/82/aec2fc9b9b149f372850291827537a508d6c4d3664b1750a324b91f71355/mypy-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93378d3203a5c0800c6b6d850ad2f19f7a3cdf1a3701d3416dbf128805c6a6a7", size = 11075338, upload-time = "2025-07-31T07:53:38.873Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ac/ee93fbde9d2242657128af8c86f5d917cd2887584cf948a8e3663d0cd737/mypy-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:15d54056f7fe7a826d897789f53dd6377ec2ea8ba6f776dc83c2902b899fee81", size = 10113066, upload-time = "2025-07-31T07:54:14.707Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/68/946a1e0be93f17f7caa56c45844ec691ca153ee8b62f21eddda336a2d203/mypy-1.17.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:209a58fed9987eccc20f2ca94afe7257a8f46eb5df1fb69958650973230f91e6", size = 11875473, upload-time = "2025-07-31T07:53:14.504Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0f/478b4dce1cb4f43cf0f0d00fba3030b21ca04a01b74d1cd272a528cf446f/mypy-1.17.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:099b9a5da47de9e2cb5165e581f158e854d9e19d2e96b6698c0d64de911dd849", size = 12744296, upload-time = "2025-07-31T07:53:03.896Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/70/afa5850176379d1b303f992a828de95fc14487429a7139a4e0bdd17a8279/mypy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa6ffadfbe6994d724c5a1bb6123a7d27dd68fc9c059561cd33b664a79578e14", size = 12914657, upload-time = "2025-07-31T07:54:08.576Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f9/4a83e1c856a3d9c8f6edaa4749a4864ee98486e9b9dbfbc93842891029c2/mypy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:9a2b7d9180aed171f033c9f2fc6c204c1245cf60b0cb61cf2e7acc24eea78e0a", size = 9593320, upload-time = "2025-07-31T07:53:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/38/56/79c2fac86da57c7d8c48622a05873eaab40b905096c33597462713f5af90/mypy-1.17.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:15a83369400454c41ed3a118e0cc58bd8123921a602f385cb6d6ea5df050c733", size = 11040037, upload-time = "2025-07-31T07:54:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c3/adabe6ff53638e3cad19e3547268482408323b1e68bf082c9119000cd049/mypy-1.17.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:55b918670f692fc9fba55c3298d8a3beae295c5cded0a55dccdc5bbead814acd", size = 10131550, upload-time = "2025-07-31T07:53:41.307Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c5/2e234c22c3bdeb23a7817af57a58865a39753bde52c74e2c661ee0cfc640/mypy-1.17.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:62761474061feef6f720149d7ba876122007ddc64adff5ba6f374fda35a018a0", size = 11872963, upload-time = "2025-07-31T07:53:16.878Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/26/c13c130f35ca8caa5f2ceab68a247775648fdcd6c9a18f158825f2bc2410/mypy-1.17.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c49562d3d908fd49ed0938e5423daed8d407774a479b595b143a3d7f87cdae6a", size = 12710189, upload-time = "2025-07-31T07:54:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/c7d79d09f6de8383fe800521d066d877e54d30b4fb94281c262be2df84ef/mypy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:397fba5d7616a5bc60b45c7ed204717eaddc38f826e3645402c426057ead9a91", size = 12900322, upload-time = "2025-07-31T07:53:10.551Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/98/3d5a48978b4f708c55ae832619addc66d677f6dc59f3ebad71bae8285ca6/mypy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:9d6b20b97d373f41617bd0708fd46aa656059af57f2ef72aa8c7d6a2b73b74ed", size = 9751879, upload-time = "2025-07-31T07:52:56.683Z" },
+    { url = "https://files.pythonhosted.org/packages/29/cb/673e3d34e5d8de60b3a61f44f80150a738bff568cd6b7efb55742a605e98/mypy-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5d1092694f166a7e56c805caaf794e0585cabdbf1df36911c414e4e9abb62ae9", size = 10992466, upload-time = "2025-07-31T07:53:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d0/fe1895836eea3a33ab801561987a10569df92f2d3d4715abf2cfeaa29cb2/mypy-1.17.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:79d44f9bfb004941ebb0abe8eff6504223a9c1ac51ef967d1263c6572bbebc99", size = 10117638, upload-time = "2025-07-31T07:53:34.256Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f3/514aa5532303aafb95b9ca400a31054a2bd9489de166558c2baaeea9c522/mypy-1.17.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b01586eed696ec905e61bd2568f48740f7ac4a45b3a468e6423a03d3788a51a8", size = 11915673, upload-time = "2025-07-31T07:52:59.361Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c3/c0805f0edec96fe8e2c048b03769a6291523d509be8ee7f56ae922fa3882/mypy-1.17.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43808d9476c36b927fbcd0b0255ce75efe1b68a080154a38ae68a7e62de8f0f8", size = 12649022, upload-time = "2025-07-31T07:53:45.92Z" },
+    { url = "https://files.pythonhosted.org/packages/45/3e/d646b5a298ada21a8512fa7e5531f664535a495efa672601702398cea2b4/mypy-1.17.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:feb8cc32d319edd5859da2cc084493b3e2ce5e49a946377663cc90f6c15fb259", size = 12895536, upload-time = "2025-07-31T07:53:06.17Z" },
+    { url = "https://files.pythonhosted.org/packages/14/55/e13d0dcd276975927d1f4e9e2ec4fd409e199f01bdc671717e673cc63a22/mypy-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d7598cf74c3e16539d4e2f0b8d8c318e00041553d83d4861f87c7a72e95ac24d", size = 9512564, upload-time = "2025-07-31T07:53:12.346Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f3/8fcd2af0f5b806f6cf463efaffd3c9548a28f84220493ecd38d127b6b66d/mypy-1.17.1-py3-none-any.whl", hash = "sha256:a9f52c0351c21fe24c21d8c0eb1f62967b262d6729393397b6f443c3b773c3b9", size = 2283411, upload-time = "2025-07-31T07:53:24.664Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "pkgconfig"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/e0/e05fee8b5425db6f83237128742e7e5ef26219b687ab8f0d41ed0422125e/pkgconfig-1.5.5.tar.gz", hash = "sha256:deb4163ef11f75b520d822d9505c1f462761b4309b1bb713d08689759ea8b899", size = 6082, upload-time = "2021-07-19T18:49:51.669Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/af/89487c7bbf433f4079044f3dc32f9a9f887597fe04614a37a292e373e16b/pkgconfig-1.5.5-py3-none-any.whl", hash = "sha256:d20023bbeb42ee6d428a0fac6e0904631f545985a10cdd71a20aa58bc47a4209", size = 6732, upload-time = "2021-07-19T18:49:50.195Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload-time = "2024-11-27T22:38:21.659Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload-time = "2024-11-27T22:38:22.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload-time = "2024-11-27T22:38:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload-time = "2024-11-27T22:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload-time = "2024-11-27T22:38:27.921Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload-time = "2024-11-27T22:38:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload-time = "2024-11-27T22:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload-time = "2024-11-27T22:38:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "types-cffi"
+version = "1.17.0.20250822"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/0c/76a48cb6e742cac4d61a4ec632dd30635b6d302f5acdc2c0a27572ac7ae3/types_cffi-1.17.0.20250822.tar.gz", hash = "sha256:bf6f5a381ea49da7ff895fae69711271e6192c434470ce6139bf2b2e0d0fa08d", size = 17130, upload-time = "2025-08-22T03:04:02.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f7/68029931e7539e3246b33386a19c475f234c71d2a878411847b20bb31960/types_cffi-1.17.0.20250822-py3-none-any.whl", hash = "sha256:183dd76c1871a48936d7b931488e41f0f25a7463abe10b5816be275fc11506d5", size = 20083, upload-time = "2025-08-22T03:04:01.466Z" },
+]
+
+[[package]]
+name = "types-setuptools"
+version = "80.9.0.20250822"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/bd/1e5f949b7cb740c9f0feaac430e301b8f1c5f11a81e26324299ea671a237/types_setuptools-80.9.0.20250822.tar.gz", hash = "sha256:070ea7716968ec67a84c7f7768d9952ff24d28b65b6594797a464f1b3066f965", size = 41296, upload-time = "2025-08-22T03:02:08.771Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/2d/475bf15c1cdc172e7a0d665b6e373ebfb1e9bf734d3f2f543d668b07a142/types_setuptools-80.9.0.20250822-py3-none-any.whl", hash = "sha256:53bf881cb9d7e46ed12c76ef76c0aaf28cfe6211d3fab12e0b83620b1a8642c3", size = 63179, upload-time = "2025-08-22T03:02:07.643Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
Adds:

- A minimal Makefile to:
  -  set up the environment
  - set up a pre-commit hook
  -  run linting and formatting
- A workflow to run linters on PRs
- Automatic only code fixes with `ruff format`
- Manual ignores for type-checking warnings

This PR shouldn't change the behavior of the code itself to fix linter/type-check warnings.  We should do that in a separate PR.